### PR TITLE
Replace ComplementAlphabet & co. with Complement

### DIFF
--- a/bio/alphabet/alphabet.pony
+++ b/bio/alphabet/alphabet.pony
@@ -9,5 +9,5 @@ trait val Alphabet[L: Letter val] is Stringable
     fun letters(): Array[L] val
     fun parse(letter: String): (L | None)
 
-trait val Complement[L: Letter val]
+interface val Complement[L: Letter val]
     fun complement(letter: L): L => letter

--- a/bio/alphabet/alphabet.pony
+++ b/bio/alphabet/alphabet.pony
@@ -9,5 +9,5 @@ trait val Alphabet[L: Letter val] is Stringable
     fun letters(): Array[L] val
     fun parse(letter: String): (L | None)
 
-trait val ComplementAlphabet[L: Letter val] is Alphabet[L]
-    fun complement(nucleotide: L): L
+trait val Complement[L: Letter val]
+    fun complement(letter: L): L => letter

--- a/bio/alphabet/gap.pony
+++ b/bio/alphabet/gap.pony
@@ -1,32 +1,6 @@
 type GapType is (Dash | Dot)
 
-class Gapped[T: Letter val, U: Alphabet[T] val] is Alphabet[(T | GapType)]
-    fun letters(): Array[(T | GapType)] val =>
-        recover val
-            let l = U.letters()
-            let res = Array[(T | GapType)](l.size() + 2)
-            res.append([as (T | GapType): Dot; Dash])
-            res.append(l)
-            res
-        end
-
-    fun string(): String iso^ =>
-        recover iso
-            let a = recover iso U.string() end
-            let res = String(a.size() + 2)
-            res.append(consume a)
-            res.append(".-")
-            res
-        end
-
-    fun parse(letter: String): (T | GapType | None) =>
-        match letter
-        | "-" => Dash
-        | "." => Dot
-        else U.parse(letter)
-        end
-
-class ComplementGapped[T: Letter val, U: ComplementAlphabet[T] val] is ComplementAlphabet[(T | GapType)]
+class Gapped[T: Letter val, U: (Alphabet[T] val & Complement[T] val)] is (Alphabet[(T | GapType)] & Complement[(T | GapType)])
     fun letters(): Array[(T | GapType)] val =>
         recover val
             let l = U.letters()

--- a/bio/alphabet/nucleotide.pony
+++ b/bio/alphabet/nucleotide.pony
@@ -2,7 +2,7 @@ type Nucleotide is (DNAType | RNAType)
 
 type RNAType is (Adenine | Cytosine | Guanine | Uracil)
 type GappedRNA is Gapped[RNAType, RNA]
-primitive RNA is ComplementAlphabet[RNAType]
+primitive RNA is (Alphabet[RNAType] & Complement[RNAType])
     fun letters(): Array[RNAType] val => [Adenine; Cytosine; Guanine; Uracil]
     fun string(): String iso^ => "ACGU".clone()
 
@@ -24,7 +24,7 @@ primitive RNA is ComplementAlphabet[RNAType]
 
 type DNAType is (Adenine | Cytosine | Guanine | Thymine)
 type GappedDNA is Gapped[DNAType, DNA]
-primitive DNA is ComplementAlphabet[DNAType]
+primitive DNA is (Alphabet[DNAType] & Complement[DNAType])
     fun letters(): Array[DNAType] val => [Adenine; Cytosine; Guanine; Thymine]
     fun string(): String iso^ => "ACGT".clone()
 
@@ -48,7 +48,7 @@ type IUPACType is (Adenine | Cytosine | Guanine | Thymine
     | Amino | Purine | Weak | Strong | Pyrimidine | Keto
     | V | H | D | B | N)
 type GappedIUPAC is Gapped[IUPACType, IUPAC]
-primitive IUPAC is ComplementAlphabet[IUPACType]
+primitive IUPAC is (Alphabet[IUPACType] & Complement[IUPACType])
     fun letters(): Array[IUPACType] val =>
         [
             Adenine; Cytosine; Guanine; Thymine


### PR DESCRIPTION
This pull request addresses #8, by getting rid of the `Complement*` duplicates and replacing all of them with `Complement[T]` - an interface exposing the `complement(letter: T)`.

The `complement` function in the `Complement[T]` interface has a default identity implementation, meaning that alphabets without `complement` can be used with other structures relying on the `complement` method. Using such `complement`-reliant features (e.g. reverse complement) would be irrelevant though.