### PR TITLE
Unify Alphabet.string() based on Alphabet.letters()

### DIFF
--- a/bio/alphabet/alphabet.pony
+++ b/bio/alphabet/alphabet.pony
@@ -12,6 +12,15 @@ trait val Alphabet[L: Letter val] is Stringable
         false
     fun letters(): Array[L] val
     fun parse(letter: String): (L | None)
+    fun string(): String iso^ => 
+        recover iso
+            let arr = this.letters()
+            let str = String(arr.size())
+            for l in arr.values() do 
+                str.append(l.oneletter())
+            end
+            str
+        end
 
 interface val Complement[L: Letter val]
     fun complement(letter: L): L => letter

--- a/bio/alphabet/gap.pony
+++ b/bio/alphabet/gap.pony
@@ -10,15 +10,6 @@ class Gapped[T: Letter val, U: (Alphabet[T] val & Complement[T] val)] is (Alphab
             res
         end
 
-    fun string(): String iso^ =>
-        recover iso
-            let a = recover iso U.string() end
-            let res = String(a.size() + 2)
-            res.append(consume a)
-            res.append(".-")
-            res
-        end
-
     fun parse(letter: String): (T | GapType | None) =>
         match letter
         | "-" => Dash

--- a/bio/alphabet/nucleotide.pony
+++ b/bio/alphabet/nucleotide.pony
@@ -4,7 +4,6 @@ type RNAType is (Adenine | Cytosine | Guanine | Uracil)
 type GappedRNA is Gapped[RNAType, RNA]
 primitive RNA is (Alphabet[RNAType] & Complement[RNAType])
     fun letters(): Array[RNAType] val => [Adenine; Cytosine; Guanine; Uracil]
-    fun string(): String iso^ => "ACGU".clone()
 
     fun parse(letter: String): (RNAType | None) =>
         match letter
@@ -26,7 +25,6 @@ type DNAType is (Adenine | Cytosine | Guanine | Thymine)
 type GappedDNA is Gapped[DNAType, DNA]
 primitive DNA is (Alphabet[DNAType] & Complement[DNAType])
     fun letters(): Array[DNAType] val => [Adenine; Cytosine; Guanine; Thymine]
-    fun string(): String iso^ => "ACGT".clone()
 
     fun parse(letter: String): (DNAType | None) =>
         match letter
@@ -55,7 +53,6 @@ primitive IUPAC is (Alphabet[IUPACType] & Complement[IUPACType])
             Amino; Purine; Weak; Strong; Pyrimidine; Keto
             V; H; D; B; N
         ]
-    fun string(): String iso^ => "AGCTMPWSYKVHDBN".clone()
 
     fun parse(letter: String): (IUPACType | None) =>
         match letter

--- a/bio/alphabet/protein.pony
+++ b/bio/alphabet/protein.pony
@@ -7,7 +7,7 @@ class val Protein is Alphabet[AminoAcid]
             Proline       ; Glutamine ; Arginine     ; Serine
             Threonine     ; Valine    ; Tryptophan   ; Tyrosine
         ]
-    fun string(): String iso^ => "ACDEFGHIKLMNPQRSTVWY".clone()
+
     fun parse(raw: String): (AminoAcid | None) =>
         if raw.size() == 1 then
             try

--- a/examples/simple-example/simple-example.pony
+++ b/examples/simple-example/simple-example.pony
@@ -10,9 +10,7 @@ actor Main
       let c = Cytosine
       let g = GappedDNA.parse("G") as DNAType
       let t = Thymine
-      env.out.print("These are the DNA nucleotides: "
-        + ", ".join([a.oneletter(); c.oneletter(); g.oneletter(); t.oneletter()].values())
-      )
+      env.out.print("These are the DNA nucleotides: " + DNA.string())
       env.out.print("Their names being, respectively:")
       env.out.print("\n".join(DNA.letters().values()))
     else


### PR DESCRIPTION
Closes #9

I added a default `Alphabet.string()` method based on `Alphabet.letters()` to get in before anyone thinks the two should be aligned because now they are! :smile: Added benefit is that an `Alphabet` implementation requires writing one fewer method now.