### PR TITLE
:art: `oneletter` -> `code`

### DIFF
--- a/bio/alphabet/alphabet.pony
+++ b/bio/alphabet/alphabet.pony
@@ -1,23 +1,26 @@
 interface val Letter is Stringable
-    fun oneletter(): String val
+    fun code(): String val
 
 trait val Alphabet[L: Letter val] is Stringable
     new val create()
     fun contains(letter: L): Bool =>
         for l in this.letters().values() do
-            if letter is l then 
+            if letter is l then
                 return true
             end
         end
         false
+
     fun letters(): Array[L] val
+
     fun parse(letter: String): (L | None)
-    fun string(): String iso^ => 
+
+    fun string(): String iso^ =>
         recover iso
             let arr = this.letters()
             let str = String(arr.size())
-            for l in arr.values() do 
-                str.append(l.oneletter())
+            for l in arr.values() do
+                str.append(l.code())
             end
             str
         end

--- a/bio/alphabet/gap.pony
+++ b/bio/alphabet/gap.pony
@@ -1,6 +1,9 @@
 type GapType is (Dash | Dot)
 
 class Gapped[T: Letter val, U: (Alphabet[T] val & Complement[T] val)] is (Alphabet[(T | GapType)] & Complement[(T | GapType)])
+    """
+    Extends the alphabet `U` with `Dash` and `Dot`.
+    """
     fun letters(): Array[(T | GapType)] val =>
         recover val
             let l = U.letters()
@@ -26,8 +29,8 @@ class Gapped[T: Letter val, U: (Alphabet[T] val & Complement[T] val)] is (Alphab
 
 primitive Dash
     fun string(): String iso^ => "-".clone()
-    fun oneletter(): String => "-"
+    fun code(): String => "-"
 
 primitive Dot
     fun string(): String iso^ => ".".clone()
-    fun oneletter(): String => "."
+    fun code(): String => "."

--- a/bio/alphabet/nucleotide.pony
+++ b/bio/alphabet/nucleotide.pony
@@ -96,66 +96,66 @@ primitive IUPAC is (Alphabet[IUPACType] & Complement[IUPACType])
 
 primitive Adenine
     fun string(): String iso^ => "Adenine".clone()
-    fun oneletter(): String => "A"
+    fun code(): String => "A"
 
 primitive Guanine
     fun string(): String iso^ => "Guanine".clone()
-    fun oneletter(): String => "G"
+    fun code(): String => "G"
 
 primitive Thymine
     fun string(): String iso^ => "Thymine".clone()
-    fun oneletter(): String => "T"
+    fun code(): String => "T"
 
 primitive Cytosine
     fun string(): String iso^ => "Cytosine".clone()
-    fun oneletter(): String => "C"
+    fun code(): String => "C"
 
 primitive Uracil
     fun string(): String iso^ =>  "Uracil".clone()
-    fun oneletter(): String => "U"
+    fun code(): String => "U"
 
 // Start IUPAC nucleotide codes
 // See: https://www.bioinformatics.org/sms/iupac.html
 primitive Amino // (Adenine | Cytosine)
     fun string(): String iso^ => "Amino".clone()
-    fun oneletter(): String => "M"
+    fun code(): String => "M"
 
 primitive Purine // (Adenine | Guanine)
     fun string(): String iso^ => "Purine".clone()
-    fun oneletter(): String => "R"
+    fun code(): String => "R"
 
 primitive Weak // (Adenine | Thymine)
     fun string(): String iso^ => "Weak".clone()
-    fun oneletter(): String => "W"
+    fun code(): String => "W"
 
 primitive Strong // (Adenine | Guanine)
     fun string(): String iso^ => "Strong".clone()
-    fun oneletter(): String => "S"
+    fun code(): String => "S"
 
 primitive Pyrimidine // (Cytosine | Thymine)
     fun string(): String iso^ => "Pyrimidine".clone()
-    fun oneletter(): String => "Y"
+    fun code(): String => "Y"
 
 primitive Keto // (Guanine | Thymine)
     fun string(): String iso^ => "Keto".clone()
-    fun oneletter(): String => "K"
+    fun code(): String => "K"
 
 primitive V // (Adenine | Cytosine | Thymine)
     fun string(): String iso^ => "V".clone()
-    fun oneletter(): String => "V"
+    fun code(): String => "V"
 
 primitive H // (Adenine | Cytosine | Thymine)
     fun string(): String iso^ => "H".clone()
-    fun oneletter(): String => "H"
+    fun code(): String => "H"
 
 primitive D // (Adenine | Cytosine | Thymine)
     fun string(): String iso^ => "D".clone()
-    fun oneletter(): String => "D"
+    fun code(): String => "D"
 
 primitive B // (Cytosine | Guanine | Thymine)
     fun string(): String iso^ => "B".clone()
-    fun oneletter(): String => "B"
+    fun code(): String => "B"
 
 primitive N // (Adenine | Guanine | Cytosine | Thymine)
     fun string(): String iso^ => "N".clone()
-    fun oneletter(): String => "N"
+    fun code(): String => "N"

--- a/bio/alphabet/protein.pony
+++ b/bio/alphabet/protein.pony
@@ -67,100 +67,100 @@ type AminoAcid is (Alanine       | Cysteine  | AsparticAcid | GlutamicAcid |
 
 primitive Alanine
     fun string(): String iso^ => "Alanine".clone()
-    fun oneletter(): String => "A"
-    fun threeletter(): String => "Ala"
+    fun code(): String => "A"
+    fun code_long(): String => "Ala"
 
 primitive Cysteine
     fun string(): String iso^ => "Cysteine".clone()
-    fun oneletter(): String => "C"
-    fun threeletter(): String => "Cys"
+    fun code(): String => "C"
+    fun code_long(): String => "Cys"
 
 primitive AsparticAcid
     fun string(): String iso^ => "Aspartic Acid".clone()
-    fun oneletter(): String => "D"
-    fun threeletter(): String => "Asp"
+    fun code(): String => "D"
+    fun code_long(): String => "Asp"
 
 primitive GlutamicAcid
     fun string(): String iso^ => "Glutamic Acid".clone()
-    fun oneletter(): String => "E"
-    fun threeletter(): String => "Glu"
+    fun code(): String => "E"
+    fun code_long(): String => "Glu"
 
 primitive Phenylalanine
     fun string(): String iso^ => "Phenylalanine".clone()
-    fun oneletter(): String => "F"
-    fun threeletter(): String => "Phe"
+    fun code(): String => "F"
+    fun code_long(): String => "Phe"
 
 primitive Glycine
     fun string(): String iso^ => "Glycine".clone()
-    fun oneletter(): String => "G"
-    fun threeletter(): String => "Gly"
+    fun code(): String => "G"
+    fun code_long(): String => "Gly"
 
 primitive Histidine
     fun string(): String iso^ => "Histidine".clone()
-    fun oneletter(): String => "H"
-    fun threeletter(): String => "His"
+    fun code(): String => "H"
+    fun code_long(): String => "His"
 
 primitive Isoleucine
     fun string(): String iso^ => "Isoleucine".clone()
-    fun oneletter(): String => "I"
-    fun threeletter(): String => "Ile"
+    fun code(): String => "I"
+    fun code_long(): String => "Ile"
 
 primitive Lysine
     fun string(): String iso^ => "Lysine".clone()
-    fun oneletter(): String => "K"
-    fun threeletter(): String => "Lys"
+    fun code(): String => "K"
+    fun code_long(): String => "Lys"
 
 primitive Leucine
     fun string(): String iso^ => "Leucine".clone()
-    fun oneletter(): String => "L"
-    fun threeletter(): String => "Leu"
+    fun code(): String => "L"
+    fun code_long(): String => "Leu"
 
 primitive Methionine
     fun string(): String iso^ => "Methionine".clone()
-    fun oneletter(): String => "M"
-    fun threeletter(): String => "Met"
+    fun code(): String => "M"
+    fun code_long(): String => "Met"
 
 primitive Asparagine
     fun string(): String iso^ => "Asparagine".clone()
-    fun oneletter(): String => "N"
-    fun threeletter(): String => "Asn"
+    fun code(): String => "N"
+    fun code_long(): String => "Asn"
 
 primitive Proline
     fun string(): String iso^ => "Proline".clone()
-    fun oneletter(): String => "P"
-    fun threeletter(): String => "Pro"
+    fun code(): String => "P"
+    fun code_long(): String => "Pro"
 
 primitive Glutamine
     fun string(): String iso^ => "Glutamine".clone()
-    fun oneletter(): String => "Q"
-    fun threeletter(): String => "Gln"
+    fun code(): String => "Q"
+    fun code_long(): String => "Gln"
 
 primitive Arginine
     fun string(): String iso^ => "Arginine".clone()
-    fun oneletter(): String => "R"
-    fun threeletter(): String => "Arg"
+    fun code(): String => "R"
+    fun code_long(): String => "Arg"
 
 primitive Serine
     fun string(): String iso^ => "Serine".clone()
-    fun oneletter(): String => "S"
-    fun threeletter(): String => "Ser"
+    fun code(): String => "S"
+    fun code_long(): String => "Ser"
 
 primitive Threonine
     fun string(): String iso^ => "Threonine".clone()
-    fun oneletter(): String => "T"
-    fun threeletter(): String => "Thr"
+    fun code(): String => "T"
+    fun code_long(): String => "Thr"
 
 primitive Valine
     fun string(): String iso^ => "Valine".clone()
-    fun oneletter(): String => "V"
-    fun threeletter(): String => "Val"
+    fun code(): String => "V"
+    fun code_long(): String => "Val"
 
 primitive Tryptophan
     fun string(): String iso^ => "Tryptophan".clone()
-    fun oneletter(): String => "W"
-    fun threeletter(): String => "Trp"
+    fun code(): String => "W"
+    fun code_long(): String => "Trp"
 
 primitive Tyrosine
     fun string(): String iso^ => "Tyrosined".clone()
-    fun oneletter(): String => "Y"
-    fun threeletter(): String => "Tyr"
+    fun code(): String => "Y"
+    fun code_long(): String => "Tyr"

--- a/bio/alphabet/protein.pony
+++ b/bio/alphabet/protein.pony
@@ -59,6 +59,21 @@ class val Protein is Alphabet[AminoAcid]
             end
         end
 
+class val ThreeLetterProtein is Alphabet[AminoAcid]
+    fun letters(): Array[AminoAcid] val => Protein.letters()
+
+    fun parse(raw: String) => Protein.parse(raw)
+
+    fun string(): String iso^ =>
+        recover iso
+            let arr = this.letters()
+            let str = String(arr.size() * 3)
+            for l in arr.values() do
+                str.append(l.code_long())
+            end
+            str
+        end
+
 type AminoAcid is (Alanine       | Cysteine  | AsparticAcid | GlutamicAcid |
                    Phenylalanine | Glycine   | Histidine    | Isoleucine   |
                    Lysine        | Leucine   | Methionine   | Asparagine   |


### PR DESCRIPTION
Closes #7 

This PR simply replaces `oneletter` with `code` and `threeletter` with `code_long`.