### PR TITLE
Close #10

### DIFF
--- a/bio/alphabet/gap.pony
+++ b/bio/alphabet/gap.pony
@@ -1,28 +1,28 @@
 use "maybe"
 
-type GapType is (Dash | Dot)
+type Gap is (Dash | Dot)
 
-class Gapped[T: Letter val, U: (Alphabet[T] val & Complement[T] val)] is (Alphabet[(T | GapType)] & Complement[(T | GapType)])
+class Gapped[T: Letter val, U: (Alphabet[T] val & Complement[T] val)] is (Alphabet[(T | Gap)] & Complement[(T | Gap)])
     """
     Extends the alphabet `U` with `Dash` and `Dot`.
     """
-    fun letters(): Array[(T | GapType)] val =>
+    fun letters(): Array[(T | Gap)] val =>
         recover val
             let l = U.letters()
-            let res = Array[(T | GapType)](l.size() + 2)
-            res.append([as (T | GapType): Dot; Dash])
+            let res = Array[(T | Gap)](l.size() + 2)
+            res.append([as (T | Gap): Dot; Dash])
             res.append(l)
             res
         end
 
-    fun parse(letter: String): Maybe[(T | GapType)] =>
+    fun parse(letter: String): Maybe[(T | Gap)] =>
         match letter
         | "-" => Dash
         | "." => Dot
         else U.parse(letter)
         end
 
-    fun complement(nucleotide: (T | GapType)): Maybe[(T | GapType)] =>
+    fun complement(nucleotide: (T | Gap)): Maybe[(T | Gap)] =>
         match nucleotide
         | Dash => Dash
         | Dot => Dot

--- a/bio/alphabet/nucleotide.pony
+++ b/bio/alphabet/nucleotide.pony
@@ -1,13 +1,13 @@
 use "maybe"
 
-type Nucleotide is (DNAType | RNAType)
+type Nucleotide is (DNALetters | RNALetters)
 
-type RNAType is (Adenine | Cytosine | Guanine | Uracil)
-type GappedRNA is Gapped[RNAType, RNA]
-primitive RNA is (Alphabet[RNAType] & Complement[RNAType])
-    fun letters(): Array[RNAType] val => [Adenine; Cytosine; Guanine; Uracil]
+type RNALetters is (Adenine | Cytosine | Guanine | Uracil)
+type GappedRNA is Gapped[RNALetters, RNA]
+primitive RNA is (Alphabet[RNALetters] & Complement[RNALetters])
+    fun letters(): Array[RNALetters] val => [Adenine; Cytosine; Guanine; Uracil]
 
-    fun parse(letter: String): Maybe[RNAType] =>
+    fun parse(letter: String): Maybe[RNALetters] =>
         match letter
         | "A" => Adenine
         | "C" => Cytosine
@@ -15,7 +15,7 @@ primitive RNA is (Alphabet[RNAType] & Complement[RNAType])
         | "U" => Uracil
         end
 
-    fun complement(nucleotide: RNAType): Maybe[RNAType] =>
+    fun complement(nucleotide: RNALetters): Maybe[RNALetters] =>
         match nucleotide
         | Adenine => Uracil
         | Cytosine => Guanine
@@ -23,12 +23,12 @@ primitive RNA is (Alphabet[RNAType] & Complement[RNAType])
         | Uracil => Adenine
         end
 
-type DNAType is (Adenine | Cytosine | Guanine | Thymine)
-type GappedDNA is Gapped[DNAType, DNA]
-primitive DNA is (Alphabet[DNAType] & Complement[DNAType])
-    fun letters(): Array[DNAType] val => [Adenine; Cytosine; Guanine; Thymine]
+type DNALetters is (Adenine | Cytosine | Guanine | Thymine)
+type GappedDNA is Gapped[DNALetters, DNA]
+primitive DNA is (Alphabet[DNALetters] & Complement[DNALetters])
+    fun letters(): Array[DNALetters] val => [Adenine; Cytosine; Guanine; Thymine]
 
-    fun parse(letter: String): Maybe[DNAType] =>
+    fun parse(letter: String): Maybe[DNALetters] =>
         match letter
         | "A" => Adenine
         | "C" => Cytosine
@@ -36,7 +36,7 @@ primitive DNA is (Alphabet[DNAType] & Complement[DNAType])
         | "T" => Thymine
         end
 
-    fun complement(nucleotide: DNAType): Maybe[DNAType] =>
+    fun complement(nucleotide: DNALetters): Maybe[DNALetters] =>
         match nucleotide
         | Adenine => Thymine
         | Cytosine => Guanine
@@ -44,19 +44,19 @@ primitive DNA is (Alphabet[DNAType] & Complement[DNAType])
         | Thymine => Adenine
         end
 
-type IUPACType is (Adenine | Cytosine | Guanine | Thymine
+type IUPACLetters is (Adenine | Cytosine | Guanine | Thymine
     | Amino | Purine | Weak | Strong | Pyrimidine | Keto
     | V | H | D | B | N)
-type GappedIUPAC is Gapped[IUPACType, IUPAC]
-primitive IUPAC is (Alphabet[IUPACType] & Complement[IUPACType])
-    fun letters(): Array[IUPACType] val =>
+type GappedIUPAC is Gapped[IUPACLetters, IUPAC]
+primitive IUPAC is (Alphabet[IUPACLetters] & Complement[IUPACLetters])
+    fun letters(): Array[IUPACLetters] val =>
         [
             Adenine; Cytosine; Guanine; Thymine
             Amino; Purine; Weak; Strong; Pyrimidine; Keto
             V; H; D; B; N
         ]
 
-    fun parse(letter: String): Maybe[IUPACType] =>
+    fun parse(letter: String): Maybe[IUPACLetters] =>
         match letter
         | "A" => Adenine
         | "C" => Cytosine
@@ -76,7 +76,7 @@ primitive IUPAC is (Alphabet[IUPACType] & Complement[IUPACType])
         else None
         end
 
-    fun complement(nucleotide: IUPACType): Maybe[IUPACType] =>
+    fun complement(nucleotide: IUPACLetters): Maybe[IUPACLetters] =>
         match nucleotide
         | Adenine => Thymine
         | Cytosine => Guanine

--- a/bio/sequence/nucleotide.pony
+++ b/bio/sequence/nucleotide.pony
@@ -1,16 +1,16 @@
 use "../alphabet"
 use "maybe"
 
-class DNASequence is Sequence[DNAType, DNA]
-  let seq: Array[DNAType] ref
+class DNASequence is Sequence[DNALetters, DNA]
+  let seq: Array[DNALetters] ref
 
-  new create(seq': Array[DNAType] box) =>
+  new create(seq': Array[DNALetters] box) =>
     seq = seq'.clone()
 
   fun length(): USize =>
     seq.size()
 
-  fun apply(pos: USize): Maybe[DNAType] =>
+  fun apply(pos: USize): Maybe[DNALetters] =>
     try seq(pos)? else None end
 
   fun reverse(): DNASequence ref =>
@@ -46,16 +46,16 @@ class DNASequence is Sequence[DNAType, DNA]
     complement_in_place()
     reverse_in_place()
 
-class RNASequence is Sequence[RNAType, RNA]
-  let seq: Array[RNAType] ref
+class RNASequence is Sequence[RNALetters, RNA]
+  let seq: Array[RNALetters] ref
 
-  new create(seq': Array[RNAType] box) =>
+  new create(seq': Array[RNALetters] box) =>
     seq = seq'.clone()
 
   fun length(): USize =>
     seq.size()
 
-  fun apply(pos: USize): Maybe[RNAType] =>
+  fun apply(pos: USize): Maybe[RNALetters] =>
     try seq(pos)? else None end
 
   fun reverse(): RNASequence =>
@@ -66,7 +66,7 @@ class RNASequence is Sequence[RNAType, RNA]
 
 primitive Transcriber
   fun to_rna(dna: DNASequence box): RNASequence ref =>
-    let res = Array[RNAType](dna.seq.size())
+    let res = Array[RNALetters](dna.seq.size())
     for letter in dna.seq.values() do
       res.push(match letter
         | Adenine => Adenine
@@ -78,7 +78,7 @@ primitive Transcriber
     RNASequence(res)
 
   fun to_dna(rna: RNASequence box): DNASequence ref =>
-    let res = Array[DNAType](rna.seq.size())
+    let res = Array[DNALetters](rna.seq.size())
     for letter in rna.seq.values() do
       res.push(match letter
         | Adenine => Adenine

--- a/examples/sequence/sequence.pony
+++ b/examples/sequence/sequence.pony
@@ -6,15 +6,15 @@ use "../../bio/sequence"
 
 actor Main
   new create(env: Env) =>
-    let sequence = DNASequence([as DNAType: Adenine; Cytosine; Adenine])
-    env.out.print("Here is a subset of the sequence `ACA`: ")
+    let sequence = DNASequence([as DNALetters: Adenine; Cytosine; Guanine])
+    env.out.print("Here is the sequence `ACG`: ")
 
-    for letter in sequence.range(1, 3) do
+    for letter in sequence.range(0, 3) do
       env.out.print(letter.string())
     end
 
     env.out.print("Here is the same sequence, reversed: ")
 
-    for letter in DNASequence(sequence.range(1, 3).collect()).reverse().range() do
+    for letter in DNASequence(sequence.range(0, 3).collect()).reverse().range() do
       env.out.print(letter.string())
     end

--- a/examples/simple-example/simple-example.pony
+++ b/examples/simple-example/simple-example.pony
@@ -6,9 +6,9 @@ use "../../bio/alphabet"
 actor Main
   new create(env: Env) =>
     try
-      let a = DNA.parse("A") as DNAType
+      let a = DNA.parse("A") as DNALetters
       let c = Cytosine
-      let g = GappedDNA.parse("G") as DNAType
+      let g = GappedDNA.parse("G") as DNALetters
       let t = Thymine
       env.out.print("These are the DNA nucleotides: " + DNA.string())
       env.out.print("Their names being, respectively:")


### PR DESCRIPTION
Changes the type aliases named as `XType` into `XLetters`, e.g. `DNAType` -> `DNALetters`

I also updated the examples for this change and took the liberty of making the `sequence` example use a input that is not the same forward and reverse.